### PR TITLE
Fix profile display & change FB callback URL for production

### DIFF
--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -7,21 +7,21 @@
 <% end %>
 <div>
   Name: <%= @user.name %><br>
-  <% unless @user.garden_website == "" %>
+  <% unless @user.garden_website == "" || @user.garden_website == nil || @user.garden_website == "http://" %>
     Garden Website: <%= link_to @display_garden_website, @user_garden_website %><br>
   <% end %>
-  <% unless @user.blurb == "" %>
+  <% unless @user.blurb == "" || @user.blurb == nil %>
     About Me: <%= @user.blurb %><br>
   <% end %>
-  <% unless @user.g_street == "" %>
+  <% unless @user.g_street == "" || @user.g_street == nil %>
     Garden Address:<br>
-    <% unless @user.g_street == "" %>
+    <% unless @user.g_street == "" || @user.g_street == nil %>
       <%= @user.g_street %><br>
     <% end %>
-    <% unless @user.g_street2 == "" %>
+    <% unless @user.g_street2 == "" || @user.g_street2 == nil %>
       <%= @user.g_street2 %><br>
     <% end %>
-    <% unless @user.g_postcode == "" %><%= @user.g_postcode %><% end %><% unless @user.g_city == "" %>, <%= @user.g_city %><% end %><% unless @user.g_country == "" %>, <%= @user.g_country %><% end %>
+    <% unless @user.g_postcode == "" || @user.g_postcode == nil %><%= @user.g_postcode %><% end %><% unless @user.g_city == "" || @user.g_city == nil %>, <%= @user.g_city %><% end %><% unless @user.g_country == "" || @user.g_country == nil %>, <%= @user.g_country %><% end %>
   <% end %>
 </div>
 <div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -249,8 +249,15 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
 
+  if Rails.env.development? || Rails.env.test?
+    callback_url = "http://localhost:3000/users/auth/facebook/callback"
+  else
+    callback_url = "http://garden-club.herokuapp.com/users/auth/facebook/callback"
+  end
+
+
   config.omniauth :facebook, ENV['FACEBOOK_APP_ID'], ENV['FACEBOOK_SECRET'],
-                callback_url: "http://localhost:3000/users/auth/facebook/callback"
+                callback_url: callback_url
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/features/profile.feature
+++ b/features/profile.feature
@@ -60,3 +60,9 @@ Scenario: I can't edit someone else's profile
   Given I am not logged in
   When I try to visit the "Edit Profile" page
   Then I should see "You need to sign in or sign up before continuing."
+
+Scenario: Viewing my own profile when I'm brand new, formatting looks nice
+  Given I am logged in as "anna@random.com"
+  When I am on the "profile" page for "Anna"
+  Then I should not see "http://"
+  Then I should not see ",,"

--- a/features/profile.feature
+++ b/features/profile.feature
@@ -64,5 +64,7 @@ Scenario: I can't edit someone else's profile
 Scenario: Viewing my own profile when I'm brand new, formatting looks nice
   Given I am logged in as "anna@random.com"
   When I am on the "profile" page for "Anna"
-  Then I should not see "http://"
-  Then I should not see ",,"
+  Then I should not see "Garden Address"
+  And I should not see "Garden Website:"
+  And I should not see "http://"
+  And I should not see ", ,"


### PR DESCRIPTION
Brand new user profiles were displaying ugly because when they haven't gone through the "edit profile" form, their values are `nil` rather than `""`. So I added in a `|| @user.key == nil` so that it could handle a situation where the user is brand new.

I also did the switch for FB test vs. production callback URL so that will hopefully work again.
