### PR TITLE
Remove default value http from edit profile page

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -35,7 +35,7 @@
 
   <div class="pure-control-group">
     <%= f.label :garden_website, 'Garden Website' %>
-    <%= f.text_field :garden_website, value: 'http://' %>
+    <%= f.text_field :garden_website %>
   </div>
 
   <div class="pure-control-group">


### PR DESCRIPTION
This was replacing the much nicer Devise default of what you already had saved. I'm handling URLs looking pretty other places, so it's unnecessary anyway.
